### PR TITLE
Add preface outline placeholder for third-edition framing

### DIFF
--- a/book/preface.asc
+++ b/book/preface.asc
@@ -1,0 +1,35 @@
+[preface]
+== Preface to the Third Edition
+
+////
+AUTHOR TODO: outline notes only — the actual preface prose must be written by a
+human author before publication (see AGENTS.md). Replace everything below with
+real prose.
+////
+
+[NOTE]
+====
+*Draft placeholder — outline notes only; prose not yet written.*
+====
+
+Points this preface needs to make:
+
+* *Timing*: edition written _before_ the Git 3.0 release
+** based on the announced/committed 3.0 breaking changes (see the
+   https://git-scm.com/docs/BreakingChanges[BreakingChanges document])
+** no firm 3.0 release date at time of writing; details could still shift
+* *Stance*: the book treats the *new 3.0 defaults as the defaults* throughout
+** `main` as the default branch name
+** SHA-256 as the default object hash for new repositories
+** `reftable` as the default ref storage backend
+** `safe.bareRepository` = `explicit`
+* *Dual paths*: some sections deliberately cover *both* the old and new behavior,
+  because readers will live with both for years
+** SHA-1 vs SHA-256 (existing repos stay SHA-1; interop story)
+** `files`/packed-refs vs `reftable` ref storage
+** `master`-named branches in older/existing repositories
+* *Readers on Git 2.x*: what to expect if their installed Git predates 3.0
+  (which defaults differ, how to opt in early — e.g. `init.defaultBranch`,
+  `--object-format`)
+* *Caveat*: commands still marked experimental at time of writing
+  (e.g. `git history`) may change by/after 3.0

--- a/progit.asc
+++ b/progit.asc
@@ -10,6 +10,8 @@ Scott Chacon; Ben Straub
 
 include::book/license.asc[]
 
+include::book/preface.asc[]
+
 include::book/introduction.asc[]
 
 include::book/ch01-getting-started.asc[]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- Add `book/preface.asc` — a "Preface to the Third Edition" containing **outline notes only** (clearly marked as a draft placeholder), to be replaced with author-written prose. The outline captures the framing points: the edition is written before Git 3.0 is released, but treats the new 3.0 defaults (`main`, SHA-256, `reftable`, `safe.bareRepository=explicit`) as the defaults, and some sections deliberately cover both paths (e.g. SHA-1 vs SHA-256).
- Wire the preface into `progit.asc` between the license and the introduction.

## Context

Per `AGENTS.md`, no reader-facing prose was written — the file is fragment bullets plus an `AUTHOR TODO` block comment (which does not render), and a visible NOTE admonition marking it as a draft placeholder.

Verified with a full `bundle exec rake book:build` (all formats build; only the pre-existing external-link check failures, which `book:build` ignores) and in the local reader:

![Rendered preface outline in the local reader](https://cursor.com/artifacts/c/art-fd80bf7b-eb8d-4eb0-960d-28a9ce7f1f70)

<a href="https://cursor.com/agents/bc-019fc210-fdbd-7a9e-977c-1592f8e2c075/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpreface_outline_in_reader_demo.mp4"><img src="https://cursor.com/artifacts/c/art-c31f54b1-d040-4ab7-bd25-a8c274cf6c16" alt="preface_outline_in_reader_demo.mp4" /></a>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc210-fdbd-7a9e-977c-1592f8e2c075?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc210-fdbd-7a9e-977c-1592f8e2c075&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

