### PR TITLE
Fix site CSS/image 404s on progit3.com (base path + CNAME)

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -44,3 +44,6 @@ jobs:
           publish_branch: gh-pages
           publish_dir: site/dist
           force_orphan: true
+          # Keep the custom-domain CNAME file on gh-pages; without this,
+          # force_orphan would delete it on every deploy and detach the domain.
+          cname: progit3.com

--- a/site/README.md
+++ b/site/README.md
@@ -62,8 +62,8 @@ The file name (without `.mdx`) becomes the URL: `/blog/<file-name>/`.
 publishes `site/dist/` to the `gh-pages` branch with
 [peaceiris/actions-gh-pages](https://github.com/peaceiris/actions-gh-pages).
 Point GitHub Pages at the `gh-pages` branch (Settings → Pages → Deploy from a
-branch) and the site is served at <https://progit.github.io/progit3/>.
+branch) and the site is served at <https://progit3.com/>.
 
-The canonical URL and base path default to `https://progit.github.io` and
-`/progit3`; override them with the `SITE_URL` and `BASE_PATH` environment
-variables (e.g. for a fork or a custom domain).
+The canonical URL and base path default to `https://progit3.com` and
+`/`; override them with the `SITE_URL` and `BASE_PATH` environment
+variables (e.g. for a fork served at `https://<user>.github.io/progit3/`).

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -2,10 +2,10 @@
 import { defineConfig } from 'astro/config';
 import mdx from '@astrojs/mdx';
 
-// GitHub Pages project site: https://progit.github.io/progit3/
-// Override SITE_URL / BASE_PATH for forks or a custom domain.
-const site = process.env.SITE_URL ?? 'https://progit.github.io';
-const base = process.env.BASE_PATH ?? '/progit3';
+// GitHub Pages with a custom domain: https://progit3.com/
+// Override SITE_URL / BASE_PATH for forks (e.g. https://<user>.github.io and /progit3).
+const site = process.env.SITE_URL ?? 'https://progit3.com';
+const base = process.env.BASE_PATH ?? '/';
 
 export default defineConfig({
   site,

--- a/site/scripts/build-book.mjs
+++ b/site/scripts/build-book.mjs
@@ -22,7 +22,7 @@ import { fileURLToPath } from 'node:url';
 
 const siteRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const repoRoot = path.resolve(siteRoot, '..');
-const base = (process.env.BASE_PATH ?? '/progit3').replace(/\/+$/, '');
+const base = (process.env.BASE_PATH ?? '/').replace(/\/+$/, '');
 
 // ---------------------------------------------------------------------------
 // 1. Make sure book/contributors.txt exists (mirrors the Rakefile task).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

https://progit3.com loads with no CSS, images, or working internal links. The HTML references every asset and page under `/progit3/` (e.g. `/progit3/_astro/Base.BrTWN6g_.css`, `/progit3/book-cover.png`, `/progit3/book/`), which 404s — GitHub Pages serves the custom domain at the root, and the files actually live at `/_astro/...`, `/book-cover.png`, etc.

The site was built with the defaults for the old project-page URL (`https://progit.github.io/progit3/`), before the `progit3.com` custom domain was attached.

## Fix

- `site/astro.config.mjs`: default `site` is now `https://progit3.com`, default `base` is `/`. Forks can still override via `SITE_URL` / `BASE_PATH`.
- `site/scripts/build-book.mjs`: same default base change for the generated book pages' image paths.
- `.github/workflows/deploy-site.yml`: add `cname: progit3.com` to the publish step. The workflow uses `force_orphan: true`, so without this the next deploy would delete the `CNAME` file that currently exists on `gh-pages` and detach the custom domain.
- `site/README.md`: update the deployment URLs to match.

## Verification

Built the site locally (`npm run build`) and served `dist/` with `astro preview`:

- No `href="/progit3` / `src="/progit3` references remain anywhere in `dist/`.
- `/`, `/book/`, `/_astro/Base.BrTWN6g_.css`, `/book-cover.png`, `/images/centralized_workflow.png`, `/pagefind/pagefind-ui.js`, and `/search/` all return 200.
- Browser walkthrough of the built site showing styles, cover image, book figures, and search all working:

<a href="https://cursor.com/agents/bc-019fc219-9422-7ca5-bc12-1113f820404a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsite_css_images_search_working_walkthrough.mp4"><img src="https://cursor.com/artifacts/c/art-05d88122-4ee3-49f3-b596-e12c46ad5923" alt="site_css_images_search_working_walkthrough.mp4" /></a>

Once merged, the deploy workflow republishes `gh-pages` and progit3.com picks up the corrected paths.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc219-9422-7ca5-bc12-1113f820404a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc219-9422-7ca5-bc12-1113f820404a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

