### PR TITLE
Label the progress-page blog post as AI-written

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,9 @@ Two hard requirements:
  write a post without loading it first.
 2. **Set `automated: true` in the frontmatter of every agent-written post.** That
  renders the "written by AI" disclosure banner; unlabeled machine writing is never
- published.
+ published. Before committing, re-read the post's frontmatter and confirm the flag
+ is there — every time, for new posts and for edits to existing agent-written
+ posts alike. If you find an agent-written post missing the flag, add it.
 
 ## Cursor Cloud specific instructions
 

--- a/site/src/content/blog/a-progress-page-for-the-third-edition.mdx
+++ b/site/src/content/blog/a-progress-page-for-the-third-edition.mdx
@@ -2,6 +2,7 @@
 title: 'A progress page for the third edition'
 description: 'Every task the third edition needs, tracked in one hand-edited file and rendered as a live progress page on this site.'
 date: 2026-08-02
+automated: true
 ---
 
 The third edition now has a **[progress page](../../blog/progress/)** — one place


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds `automated: true` to the frontmatter of `site/src/content/blog/a-progress-page-for-the-third-edition.mdx`, so the post carries the "This post was written by AI" banner and the "Written by AI" tag in the post list, like the other two agent-written posts.
- Strengthens requirement 2 in `AGENTS.md` (and `CLAUDE.md`, which is a symlink to it): agents must re-read the frontmatter before committing and confirm the flag is present, for new posts and edits alike, and must add the flag to any agent-written post found missing it.

## Verification

- `npm run build` in `site/` succeeds; the generated `dist/blog/a-progress-page-for-the-third-edition/index.html` contains the `authorship-ai` banner ("This post was written by AI."), and the blog index now shows three "Written by AI" tags.
- Verified in the browser on `astro preview`:

<a href="https://cursor.com/agents/bc-019fc23d-29cc-7bb4-b773-e5120ff37e46/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_written_by_ai_labels_demo.mp4"><img src="https://cursor.com/artifacts/c/art-0e62d4b6-e01e-49c7-b57e-9b58558e8a66" alt="blog_written_by_ai_labels_demo.mp4" /></a>

![Progress-page post with the AI authorship banner](https://cursor.com/artifacts/c/art-3caef43a-a444-4d8b-981c-cd8077446592)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc23d-29cc-7bb4-b773-e5120ff37e46?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc23d-29cc-7bb4-b773-e5120ff37e46&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

