### PR TITLE
Add ebook download links to progit3.com/book/

### DIFF
--- a/site/src/pages/book/index.astro
+++ b/site/src/pages/book/index.astro
@@ -2,6 +2,16 @@
 import Base from '../../layouts/Base.astro';
 import { url } from '../../lib/url';
 import book from '../../generated/book.json';
+
+// Ebook files are attached to a GitHub release on every merge to main
+// (see .github/workflows/release-on-merge.yml); "latest" always points there.
+const downloadBase = 'https://github.com/progit/progit3/releases/latest/download';
+const downloads = [
+  { label: 'PDF', file: 'progit.pdf' },
+  { label: 'EPUB', file: 'progit.epub' },
+  { label: 'FB2', file: 'progit.fb2.zip' },
+  { label: 'HTML', file: 'progit.html' },
+];
 ---
 
 <Base title="Read Pro Git online — Table of Contents" description="The complete Pro Git book, one page per section. Free to read.">
@@ -13,6 +23,12 @@ import book from '../../generated/book.json';
         <p class="lede">
           Read the whole book right here, one section at a time — or
           <a href={url('/search/')}>search it</a> for what you need.
+        </p>
+        <p class="downloads">
+          Download:
+          {downloads.map((d) => (
+            <a href={`${downloadBase}/${d.file}`}>{d.label}</a>
+          ))}
         </p>
         <p class="rev">Built from the sources · rev {book.revnumber} · {book.revdate}</p>
       </div>
@@ -61,6 +77,29 @@ import book from '../../generated/book.json';
     color: var(--muted);
     font-size: 1.1rem;
     margin: 0 0 0.6rem;
+  }
+
+  .downloads {
+    color: var(--muted);
+    font-size: 0.95rem;
+    margin: 0 0 0.6rem;
+  }
+
+  .downloads a {
+    display: inline-block;
+    margin-left: 0.35rem;
+    padding: 0.1rem 0.6rem;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    color: var(--accent);
+    font-size: 0.85rem;
+    text-decoration: none;
+  }
+
+  .downloads a:hover {
+    background: var(--accent);
+    color: var(--bg);
+    border-color: var(--accent);
   }
 
   .rev {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a "Download:" row to the book index page (`/book/`) on the site, linking **PDF · EPUB · FB2 · HTML** as pill-style links next to the book cover.

The links point at the stable GitHub `releases/latest/download/...` URLs — `release-on-merge.yml` attaches these four files to a new release on every merge to main, so the links always serve the most recent build with no site changes needed per release. MOBI is deliberately not linked: the workflow lists it, but the current `asciidoctor-epub3` toolchain never produces it (known no-op), so a link would 404.

## Verification

- `npm run build` in `site/` succeeds; the generated `/book/` page contains all four links (verified in `dist/`).
- `https://github.com/progit/progit3/releases/latest/download/progit.pdf` responds with a 302 to the current release asset (2.1.17 has all four files).
- Browser demo on the local preview — pills render, hover style works, and the status bar shows the correct target URL:

![Book page with Download pills; status bar shows the releases/latest URL](https://cursor.com/artifacts/c/art-c8e8a6ba-98cc-423e-b4fa-d9b723df7b30)

<a href="https://cursor.com/agents/bc-019fc741-c8c0-7685-8620-210236ea6d3c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbook_page_download_links_demo.mp4"><img src="https://cursor.com/artifacts/c/art-10c2fb37-21b5-4ce8-80cb-3f0c3c405fda" alt="book_page_download_links_demo.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc741-c8c0-7685-8620-210236ea6d3c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc741-c8c0-7685-8620-210236ea6d3c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

